### PR TITLE
fixed structure added priceHistory to every PokemonCard in cardInfo.tsx

### DIFF
--- a/src/Components/ProductCard/cardInfo.ts
+++ b/src/Components/ProductCard/cardInfo.ts
@@ -19,11 +19,18 @@ export type priceHistoryData = {
 const cardInfo: PokemonCard[] = [
   {
     id: 123,
-    name: "Charmand",
+    name: "Charmander",
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ] 
   },
   {
     id: 321,
@@ -31,7 +38,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,
@@ -39,7 +52,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 321,
@@ -47,7 +66,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,
@@ -55,7 +80,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 321,
@@ -63,7 +94,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,
@@ -71,7 +108,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 321,
@@ -79,7 +122,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,
@@ -87,7 +136,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 321,
@@ -95,7 +150,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,
@@ -103,7 +164,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 321,
@@ -111,7 +178,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,
@@ -119,7 +192,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 321,
@@ -127,7 +206,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,
@@ -135,7 +220,14 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ] 
   },
   {
     id: 321,
@@ -143,7 +235,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,
@@ -151,7 +249,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 321,
@@ -159,7 +263,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,
@@ -167,7 +277,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 321,
@@ -175,7 +291,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,
@@ -183,7 +305,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 321,
@@ -191,7 +319,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,
@@ -199,7 +333,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 321,
@@ -207,7 +347,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,
@@ -215,7 +361,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 321,
@@ -223,7 +375,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,
@@ -231,7 +389,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.23,
     marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 321,
@@ -239,55 +403,13 @@ const cardInfo: PokemonCard[] = [
     description: "Card Description here",
     salePrice: 12.13,
     marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
-  },
-  {
-    id: 123,
-    name: "Charmander",
-    description: "Card Description here",
-    salePrice: 12.23,
-    marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
-  },
-  {
-    id: 321,
-    name: "Pikachu",
-    description: "Card Description here",
-    salePrice: 12.13,
-    marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
-  },
-  {
-    id: 123,
-    name: "Charmander",
-    description: "Card Description here",
-    salePrice: 12.23,
-    marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
-  },
-  {
-    id: 321,
-    name: "Pikachu",
-    description: "Card Description here",
-    salePrice: 12.13,
-    marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
-  },
-  {
-    id: 123,
-    name: "Charmander",
-    description: "Card Description here",
-    salePrice: 12.23,
-    marketPrice: 11.99,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/SMA/SMA_EN_SV6.png"
-  },
-  {
-    id: 321,
-    name: "Pikachu",
-    description: "Card Description here",
-    salePrice: 12.13,
-    marketPrice: 11.89,
-    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png"
+    image: "https://assets.pokemon.com/assets/cms2/img/cards/web/BWP/BWP_EN_BW54.png", 
+    priceHistory: [
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}, 
+      {month: 2, day: 1, year: 2023, quantity: 1, price: 3.99}
+    ]
   },
   {
     id: 123,


### PR DESCRIPTION
When I added a bunch of PokemonCards to cardInfo.tsx I did not add in the pricehistory part. So this branch is fixing that.