### PR TITLE
paginate-get-test

### DIFF
--- a/api/src/controllers/cards.controller.ts
+++ b/api/src/controllers/cards.controller.ts
@@ -4,6 +4,7 @@ import { User } from '@interfaces/users.interface';
 import { UserService } from '@services/users.service';
 import { PokemonCard } from '@interfaces/cards.interface';
 import { CardService } from '@/services/cards.service';
+import { PokemonCardModel } from '@/models/cards.model';
 
 // All routes that will need controllers
 // Create new card: POST /cards
@@ -25,8 +26,14 @@ export class CardsController {
   public getCards = async (req: Request, res: Response, next: NextFunction) => {
     try {
       // Initialize our page to 1 and our limit to 12 (12 cards per page)
-      const page = req.query.page || 1;
-      const limit = 12;
+      let page: number = Number(req.query.page) || 1;
+      const limit: number = 12;
+
+      // Store total number of pages and if page goes past the number of pages then set page to the last page
+      const totalNumberOfPages: number = Math.ceil((await PokemonCardModel.find()).length / limit);
+      if (page > totalNumberOfPages) {
+        page = totalNumberOfPages;
+      }
 
       const findAllCardsData: PokemonCard[] = await this.card.findAllCards(page, limit);
 

--- a/api/src/controllers/cards.controller.ts
+++ b/api/src/controllers/cards.controller.ts
@@ -24,7 +24,11 @@ export class CardsController {
   // Controller to get all cards this will be used for the main page.
   public getCards = async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const findAllCardsData: PokemonCard[] = await this.card.findAllCards();
+      // Initialize our page to 1 and our limit to 12 (12 cards per page)
+      const page = req.query.page || 1;
+      const limit = 12;
+
+      const findAllCardsData: PokemonCard[] = await this.card.findAllCards(page, limit);
 
       res.status(200).json({ data: findAllCardsData, message: 'findAll' });
     } catch (error) {

--- a/api/src/services/cards.service.ts
+++ b/api/src/services/cards.service.ts
@@ -8,7 +8,7 @@ import { PokemonCardModel } from '@/models/cards.model';
 
 @Service()
 export class CardService {
-  public async findAllCards(page: any, limit: any): Promise<PokemonCard[]> {
+  public async findAllCards(page: number, limit: number): Promise<PokemonCard[]> {
     // Still need PokemonCardModel
     const cards: PokemonCard[] = await PokemonCardModel.find()
     // Ensure the limit is a number by multipling by 1

--- a/api/src/services/cards.service.ts
+++ b/api/src/services/cards.service.ts
@@ -8,9 +8,14 @@ import { PokemonCardModel } from '@/models/cards.model';
 
 @Service()
 export class CardService {
-  public async findAllCards(): Promise<PokemonCard[]> {
+  public async findAllCards(page: any, limit: any): Promise<PokemonCard[]> {
     // Still need PokemonCardModel
-    const cards: PokemonCard[] = await PokemonCardModel.find();
+    const cards: PokemonCard[] = await PokemonCardModel.find()
+    // Ensure the limit is a number by multipling by 1
+    .limit(limit * 1)
+    // Skip the correct number of pages based on current page
+    // ie page 1 skip 0 cards
+    .skip((page - 1) * limit);
     return cards;
   }
 

--- a/api/src/test/cards.test.ts
+++ b/api/src/test/cards.test.ts
@@ -141,8 +141,8 @@ describe('Testing Cards', () => {
     it('Page 2', async () => {
       const result = await request(app.getServer()).get(`${cardsRoute.path}?page=2`);
       expect(result.status).toEqual(200);
-      // Check to see that the there is 12 cards 
-      expect(result.body.data.length).toBe(12);
+      // Check to see that the there is at least 1 card on the second page
+      expect(result.body.data.length).toBeGreaterThanOrEqual(1);
       // First card on page 2 should be card 13
       expect(result.body.data[0].name).toBe("Card 13");
       // Check if the first items id is a length of 24.

--- a/api/src/test/cards.test.ts
+++ b/api/src/test/cards.test.ts
@@ -125,11 +125,26 @@ describe('Testing Cards', () => {
 
   // GET all cards. 
   describe('[GET] /card', () => {
-    it('response statusCode 200', async () => {
+    // Test no query passed
+    it('Default page', async () => {
       const result = await request(app.getServer()).get(`${cardsRoute.path}`);
       expect(result.status).toEqual(200);
-      // Check to see that the there is at least one value.
-      expect(result.body.data.length).toBeGreaterThanOrEqual(1);
+      // Check to see that the there is 12 cards 
+      expect(result.body.data.length).toBe(12);
+      // First card on default page (page 1) should be Card 1
+      expect(result.body.data[0].name).toBe("Card 1");
+      // Check if the first items id is a length of 24.
+      // Mongo Object ID data types are a 24 character hexadecimal code.
+      expect(result.body.data[0]._id).toHaveLength(24);
+    });
+    // Test page=2 passed as query
+    it('Page 2', async () => {
+      const result = await request(app.getServer()).get(`${cardsRoute.path}?page=2`);
+      expect(result.status).toEqual(200);
+      // Check to see that the there is 12 cards 
+      expect(result.body.data.length).toBe(12);
+      // First card on page 2 should be card 13
+      expect(result.body.data[0].name).toBe("Card 13");
       // Check if the first items id is a length of 24.
       // Mongo Object ID data types are a 24 character hexadecimal code.
       expect(result.body.data[0]._id).toHaveLength(24);


### PR DESCRIPTION
#60 

Made the GET cards endpoint paginate cards 12 at a time. Also updated the GET cards tests to also make sure the paginate is working properly.

The first test checks the default endpoint which contains no query. When no query is passed the page is defaulted to 1. So the test checks to make sure the endpoint gets the first 12 cards.

The second test checks if a query of "page=2" is passed to the request URL. So the test then tests to make sure it is getting the next 12 cards. 