### PR TITLE
Made the search-card-by-name endpoint.

### DIFF
--- a/api/src/controllers/cards.controller.ts
+++ b/api/src/controllers/cards.controller.ts
@@ -30,15 +30,36 @@ export class CardsController {
     try {
       // Initialize our page to 1 and our limit to 12 (12 cards per page)
       let page: number = Number(req.query.page) || 1;
+      if(page < 0) {
+        page = 1; 
+      }
       const limit: number = 12;
 
-      // Store total number of pages and if page goes past the number of pages then set page to the last page
-      const totalNumberOfPages: number = Math.ceil((await PokemonCardModel.find()).length / limit);
-      if (page > totalNumberOfPages) {
-        page = totalNumberOfPages;
+      const cardName: string | undefined = req.query.name as string | undefined; 
+      const searchByName: boolean = cardName && typeof cardName == "string"
+      
+      if(searchByName) {
+        /*  Store total number of pages
+          If page goes past the number of pages, 
+          then set page to the last page
+        */
+        const totalNumberOfPages: number = Math.ceil((await PokemonCardModel.find({name: `${cardName}`})).length / limit);
+        if (page > totalNumberOfPages) {
+          page = totalNumberOfPages;
+        }
       }
+      else {
+        /*  Store total number of pages
+          If page goes past the number of pages, 
+          then set page to the last page
+        */
+        const totalNumberOfPages: number = Math.ceil((await PokemonCardModel.find()).length / limit);
+        if (page > totalNumberOfPages) {
+          page = totalNumberOfPages;
+        }
+      }      
 
-      const findAllCardsData: PokemonCard[] = await this.card.findAllCards(page, limit);
+      const findAllCardsData: PokemonCard[] = await this.card.findAllCards(page, limit, searchByName, cardName);
 
       res.status(200).json({ data: findAllCardsData, message: 'findAll' });
     } catch (error) {

--- a/api/src/controllers/cards.controller.ts
+++ b/api/src/controllers/cards.controller.ts
@@ -30,7 +30,7 @@ export class CardsController {
     try {
       // Initialize our page to 1 and our limit to 12 (12 cards per page)
       let page: number = Number(req.query.page) || 1;
-      if(page < 0) {
+      if(page < 1) {
         page = 1; 
       }
       const limit: number = 12;

--- a/api/src/routes/cards.route.ts
+++ b/api/src/routes/cards.route.ts
@@ -16,13 +16,14 @@ export class CardsRoute implements Routes {
   }
 
   private initializeRoutes() {
+    this.router.get(`${this.path}`, this.card.getCards);
+
     // Route for post request for creating a new card
     this.router.post(`${this.path}`, ValidationMiddleware(CreateCardDto), this.card.createCard);
 
     // Route for post request for creating a new price history entry
     this.router.post(`${this.path}/:id/price-history`, ValidationMiddleware(CreatePriceHistoryDto), this.card.createPriceHistory)
 
-    this.router.get(`${this.path}`, this.card.getCards);
     this.router.get(`${this.path}/:id`, this.card.getCardById);
   }
 }

--- a/api/src/services/cards.service.ts
+++ b/api/src/services/cards.service.ts
@@ -31,7 +31,6 @@ export class CardService {
       .skip((page - 1) * limit);
       return cards;
     }
-    
   }
 
   public async findCardById(cardId: string, includePriceHistory: boolean): Promise<PokemonCard> {

--- a/api/src/services/cards.service.ts
+++ b/api/src/services/cards.service.ts
@@ -11,15 +11,27 @@ import { ObjectId } from 'mongoose';
 
 @Service()
 export class CardService {
-  public async findAllCards(page: number, limit: number): Promise<PokemonCard[]> {
-    // Still need PokemonCardModel
-    const cards: PokemonCard[] = await PokemonCardModel.find()
-    // Ensure the limit is a number by multipling by 1
-    .limit(limit * 1)
-    // Skip the correct number of pages based on current page
-    // ie page 1 skip 0 cards
-    .skip((page - 1) * limit);
-    return cards;
+  public async findAllCards(page: number, limit: number, searchByName: boolean, cardName: string | undefined): Promise<PokemonCard[]> {
+
+    if(searchByName) {
+      const cards: PokemonCard[] = await PokemonCardModel.find({name: `${cardName}`})
+      // Ensure the limit is a number by multipling by 1
+      .limit(limit * 1)
+      // Skip the correct number of pages based on current page
+      // ie page 1 skip 0 cards
+      .skip((page - 1) * limit);
+      return cards;
+    }
+    else {
+      const cards: PokemonCard[] = await PokemonCardModel.find()
+      // Ensure the limit is a number by multipling by 1
+      .limit(limit * 1)
+      // Skip the correct number of pages based on current page
+      // ie page 1 skip 0 cards
+      .skip((page - 1) * limit);
+      return cards;
+    }
+    
   }
 
   public async findCardById(cardId: string, includePriceHistory: boolean): Promise<PokemonCard> {

--- a/api/src/test/cards.test.ts
+++ b/api/src/test/cards.test.ts
@@ -179,6 +179,43 @@ describe('Testing Cards', () => {
       // Mongo Object ID data types are a 24 character hexadecimal code.
       expect(result.body.data[0]._id).toHaveLength(24);
     });
+
+    // GET card by name
+    it('Query name of card', async () => {
+      const cardName1 : string = createdCards[0].name;
+      const result = await request(app.getServer()).get(`${cardsRoute.path}?name=${cardName1}`);
+    
+      expect(result.status).toEqual(200);
+      expect(result.body.data.length).toBeGreaterThanOrEqual(1);
+      expect(result.body.data[0].name).toBe("Card 1");
+      expect(result.body.data[0]._id).toHaveLength(24);
+    });
+
+    // GET card by name and page
+    it('Query name of card and page number', async () => {
+
+      const testCard1 : PokemonCard = {
+        name: 'SearchCardQuery', 
+        description: 'Search', 
+        salePrice: 1, 
+        marketPrice: 2, 
+        rating: [], 
+        image: 'img',
+      }
+      let createdSameNameCards: PokemonCard[] = [];
+      // Create multiple cards with same name
+      for (let i: number = 0; i < 15; i++) {
+        createdSameNameCards[i] = await PokemonCardModel.create(testCard1);
+      }
+
+      const result = await request(app.getServer()).get(`${cardsRoute.path}?name=${testCard1.name}&page=2`);
+    
+      expect(result.status).toEqual(200);
+      // Expect 3 cards on second page (15 cards total - 12 card limit)
+      expect(result.body.data.length).toEqual(3);
+      expect(result.body.data[0].name).toBe("SearchCardQuery");
+      expect(result.body.data[0]._id).toHaveLength(24);
+    });
   });
 
   // GET card by ID


### PR DESCRIPTION
Created under the get-all-cards endpoint, instead of having a separate endpoint such as `/card/search?name=value`. This is because our current frontend has the search bar on the home page. When we search for a card name, all corresponding cards will appear on the home page. 