### PR TITLE
Prevent API search request overload

### DIFF
--- a/app/src/Components/DisplayCards/DisplayCards.tsx
+++ b/app/src/Components/DisplayCards/DisplayCards.tsx
@@ -14,24 +14,34 @@ function DisplayCards ({ search, sortBy, order }: Props) {
   const [pageNumber, setPageNumber] = useState(0);
   const [cards, setCards] = useState<PokemonCard[]>([]);
   const [totalPages, setTotalPages] = useState(0);
+
+  const [isLoading, setIsLoading] = useState(false);
   
   // 12 Cards per page
-  const limit: number = 12;
+  const CARD_LIMIT: number = 12;
+  const SEARCH_DELAY: number = 300;
+
   
   // Update the cards each time the user changes the page
   useEffect(() => {
-    const fetchCurrentCards = async() => {
-      try {
-        const result = await fetch(`http://localhost:3000/cards/?page=${pageNumber + 1}&limit=${limit}&name=${search}&sort=${sortBy}&order=${order}`);
-        const data = await result.json();
-        setCards(data.data);
-        setTotalPages(data.totalPages);
-        console.log(search);
-      } catch (error) {
-        console.error(error);
-      }
-    };
-    fetchCurrentCards();
+    setIsLoading(true);
+
+    const timerId = setTimeout(() => {
+      const fetchCurrentCards = async() => {
+        try {
+          const result = await fetch(`http://localhost:3000/cards/?page=${pageNumber + 1}&limit=${CARD_LIMIT}&name=${search}&sort=${sortBy}&order=${order}`);
+          const data = await result.json();
+          setCards(data.data);
+          setTotalPages(data.totalPages);
+          console.log(search);
+
+          setIsLoading(false);
+        } catch (error) {
+          console.error(error);
+        }
+      };
+      fetchCurrentCards();
+    }, SEARCH_DELAY); 
   }, [pageNumber, search, sortBy, order]);
 
   // Map all of the current cards
@@ -47,7 +57,10 @@ function DisplayCards ({ search, sortBy, order }: Props) {
     setPageNumber(selected);
   };
 
+
+  
   return (
+
     <div className="page-container">
       <div className="pagination-container">
         <h4>Page {pageNumber + 1} of {totalPages}</h4>
@@ -61,11 +74,14 @@ function DisplayCards ({ search, sortBy, order }: Props) {
           breakClassName={"break-btn"}
         />
       </div>
+      {isLoading && <h1>Loading...</h1>}
       <div className="card-container">
         {displaySetOfCards}
       </div>
     </div>
   );
+
+  
 }
 
 export default DisplayCards;

--- a/app/src/Components/DisplayCards/DisplayCards.tsx
+++ b/app/src/Components/DisplayCards/DisplayCards.tsx
@@ -3,6 +3,7 @@ import ProductCard from "../ProductCard/ProductCard";
 import './DisplayCards.css';
 import ReactPaginate from "react-paginate";
 import { PokemonCard } from "../../../../api/src/interfaces/cards.interface";
+import { set } from "mongoose";
 
 interface Props {
   search?: string,
@@ -21,27 +22,31 @@ function DisplayCards ({ search, sortBy, order }: Props) {
   const CARD_LIMIT: number = 12;
   const SEARCH_DELAY: number = 300;
 
-  
-  // Update the cards each time the user changes the page
   useEffect(() => {
+
+    // Bring up loading symbol
     setIsLoading(true);
 
-    const timerId = setTimeout(() => {
-      const fetchCurrentCards = async() => {
-        try {
-          const result = await fetch(`http://localhost:3000/cards/?page=${pageNumber + 1}&limit=${CARD_LIMIT}&name=${search}&sort=${sortBy}&order=${order}`);
-          const data = await result.json();
-          setCards(data.data);
-          setTotalPages(data.totalPages);
-          console.log(search);
+    // Fetch cards after specified delay to prevent spamming the API
+    const fetchCurrentCards = setTimeout(async () => {
+      try {
+        // Fetch the cards from the API
+        const result = await fetch(`http://localhost:3000/cards/?page=${pageNumber + 1}&limit=${CARD_LIMIT}&name=${search}&sort=${sortBy}&order=${order}`);
+        const data = await result.json();
+        setCards(data.data);
+        setTotalPages(data.totalPages);
+        console.log(search);
 
-          setIsLoading(false);
-        } catch (error) {
-          console.error(error);
-        }
-      };
-      fetchCurrentCards();
-    }, SEARCH_DELAY); 
+        // Remove loading symbol
+        setIsLoading(false);
+      } 
+      catch (error) {
+        console.error(error);
+      }
+    }, SEARCH_DELAY)
+
+
+    return () => clearTimeout(fetchCurrentCards)
   }, [pageNumber, search, sortBy, order]);
 
   // Map all of the current cards
@@ -75,6 +80,7 @@ function DisplayCards ({ search, sortBy, order }: Props) {
         />
       </div>
       {isLoading && <h1>Loading...</h1>}
+      {!isLoading && (!cards || cards.length === 0) && <h1>No cards found</h1>}
       <div className="card-container">
         {displaySetOfCards}
       </div>


### PR DESCRIPTION
- Implemented debounce feature using setTimeout() to prevent too many calls on the API at the same time
- Created text popups for 'loading' and 'no cards found'