### PR TITLE
Return to Page 1

### DIFF
--- a/app/src/Components/DisplayCards/DisplayCards.tsx
+++ b/app/src/Components/DisplayCards/DisplayCards.tsx
@@ -5,9 +5,9 @@ import ReactPaginate from "react-paginate";
 import { PokemonCard } from "../../../../api/src/interfaces/cards.interface";
 
 interface Props {
-  search?: string,
-  sortBy?: string,
-  order?: string
+  search: string,
+  sortBy: string,
+  order: string
 }
 
 function DisplayCards ({ search, sortBy, order }: Props) {
@@ -21,9 +21,9 @@ function DisplayCards ({ search, sortBy, order }: Props) {
   const SEARCH_DELAY: number = 300;
 
   // State variables to see if search value changes (useful when user changes a filter past page 1)
-  const [prevSearch, setPrevSearch] = useState<string | undefined>(undefined);
-  const [prevSortBy, setPrevSortBy] = useState<string | undefined>(undefined);
-  const [prevOrder, setPrevOrder] = useState<string | undefined>(undefined);
+  const [prevSearch, setPrevSearch] = useState<string | "">("");
+  const [prevSortBy, setPrevSortBy] = useState<string | "">("");
+  const [prevOrder, setPrevOrder] = useState<string | "">("");
 
   useEffect(() => {
     // Bring up loading symbol

--- a/app/src/Components/DisplayCards/DisplayCards.tsx
+++ b/app/src/Components/DisplayCards/DisplayCards.tsx
@@ -1,9 +1,8 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import ProductCard from "../ProductCard/ProductCard";
 import './DisplayCards.css';
 import ReactPaginate from "react-paginate";
 import { PokemonCard } from "../../../../api/src/interfaces/cards.interface";
-import { set } from "mongoose";
 
 interface Props {
   search?: string,
@@ -15,23 +14,40 @@ function DisplayCards ({ search, sortBy, order }: Props) {
   const [pageNumber, setPageNumber] = useState(0);
   const [cards, setCards] = useState<PokemonCard[]>([]);
   const [totalPages, setTotalPages] = useState(0);
-
   const [isLoading, setIsLoading] = useState(false);
   
   // 12 Cards per page
   const CARD_LIMIT: number = 12;
   const SEARCH_DELAY: number = 300;
 
-  useEffect(() => {
+  // State variables to see if search value changes (useful when user changes a filter past page 1)
+  const [prevSearch, setPrevSearch] = useState<string | undefined>(undefined);
+  const [prevSortBy, setPrevSortBy] = useState<string | undefined>(undefined);
+  const [prevOrder, setPrevOrder] = useState<string | undefined>(undefined);
 
+  useEffect(() => {
     // Bring up loading symbol
     setIsLoading(true);
+
+    // Check if filters Changed
+    const filtersHaveChanged = search !== prevSearch || sortBy !== prevSortBy || order !== prevOrder;
+    // If they have set page back to 1.
+    if (filtersHaveChanged) {
+      setPageNumber(0);
+      // Force ReactPaginate to display the first page
+      // This ensures the correct active page is displayed after filter changes
+      if (paginationComponentRef.current) {
+        paginationComponentRef.current.state.selected = 0;
+      }
+    }
 
     // Fetch cards after specified delay to prevent spamming the API
     const fetchCurrentCards = setTimeout(async () => {
       try {
         // Fetch the cards from the API
-        const result = await fetch(`http://localhost:3000/cards/?page=${pageNumber + 1}&limit=${CARD_LIMIT}&name=${search}&sort=${sortBy}&order=${order}`);
+        const result = await fetch(
+          `http://localhost:3000/cards/?page=${pageNumber + 1}&limit=${CARD_LIMIT}&name=${search}&sort=${sortBy}&order=${order}`
+        );
         const data = await result.json();
         setCards(data.data);
         setTotalPages(data.totalPages);
@@ -45,9 +61,15 @@ function DisplayCards ({ search, sortBy, order }: Props) {
       }
     }, SEARCH_DELAY)
 
-
     return () => clearTimeout(fetchCurrentCards)
-  }, [pageNumber, search, sortBy, order]);
+  }, [pageNumber, search, sortBy, order, prevSearch, prevSortBy, prevOrder]);
+
+  useEffect(() => {
+    // Update previous filter values
+    setPrevSearch(search);
+    setPrevSortBy(sortBy);
+    setPrevOrder(order);
+  }, [search, sortBy, order]);
 
   // Map all of the current cards
   const displaySetOfCards = cards && cards.map((card) => {
@@ -62,14 +84,15 @@ function DisplayCards ({ search, sortBy, order }: Props) {
     setPageNumber(selected);
   };
 
-
+  // reference the pagination component
+  const paginationComponentRef = useRef<any>(null);
   
   return (
-
     <div className="page-container">
       <div className="pagination-container">
         <h4>Page {pageNumber + 1} of {totalPages}</h4>
         <ReactPaginate 
+          ref={paginationComponentRef}
           pageCount={totalPages}
           previousLabel={"<"}
           nextLabel={">"}
@@ -86,8 +109,6 @@ function DisplayCards ({ search, sortBy, order }: Props) {
       </div>
     </div>
   );
-
-  
 }
 
 export default DisplayCards;


### PR DESCRIPTION
Fixed bug where if the user is past page 1 and they change the search or sort the app now returns them to page 1. Before the app would kind of break.

My theory was right I needed to add new state variables of the previous search, sort, and order values. Now we can use these to compare to the current state so that if they change it returns the user to page 1.

#98 