### PR TITLE
Implement Rating Feature (Backend API, Fixed Frontend, Connected Everything)

### DIFF
--- a/api/src/controllers/cards.controller.ts
+++ b/api/src/controllers/cards.controller.ts
@@ -126,8 +126,8 @@ export class CardsController {
       priceHistoryData.pokemonCardId = cardId; 
 
       // Pass in priceHistoryData into the cards service method createPriceHistory()
-      // This will create a new card in the database and return it
-      const createdPriceHistory : PriceHistory = await this.card.createPriceHistory(cardId, priceHistoryData); 
+      // This will create a new price history entry in the database and return it
+      const createdPriceHistory : PriceHistory = await this.card.createPriceHistory(priceHistoryData); 
 
       // Send response back to user with HTTP status code 201 and 
       // created price history obj in JSON form
@@ -149,12 +149,12 @@ export class CardsController {
       // const priceHistoryData : CreatePriceHistoryDto = req.body;
       const cardId : ObjectId | string = req.params.id; 
       
-      // Inject the cardId from the URL path into priceHistoryData
+      // Inject the cardId from the URL path into cardRatingData
       cardRatingData.pokemonCardId = cardId; 
 
-      // Pass in priceHistoryData into the cards service method createPriceHistory()
-      // This will create a new card in the database and return it
-      const createdCardRating : CardRating = await this.card.createCardRating(cardId, cardRatingData); 
+      // Pass in cardRatingData into the cards service method createCardRating()
+      // This will create a new card rating entry in the database and return it
+      const createdCardRating : CardRating = await this.card.createCardRating(cardRatingData); 
 
       // Send response back to user with HTTP status code 201 and 
       // created price history obj in JSON form

--- a/api/src/controllers/cards.controller.ts
+++ b/api/src/controllers/cards.controller.ts
@@ -4,6 +4,7 @@ import { PokemonCard } from '@interfaces/cards.interface';
 import { CardService } from '@/services/cards.service';
 import { PokemonCardModel } from '@/models/cards.model';
 import { PriceHistory } from '@/interfaces/priceHistory.interface';
+import { CardRating } from '@/interfaces/cardRating.interface';
 import { ObjectId } from 'mongoose';
 
 // All routes that will need controllers
@@ -65,8 +66,26 @@ export class CardsController {
   public getCardById = async (req: Request, res: Response, next: NextFunction) => {
     try { 
       const cardId: string = req.params.id;
-      const includePriceHistory : boolean = req.query.include === 'price-history';
-      const findOneCardData: PokemonCard = await this.card.findCardById(cardId, includePriceHistory);
+      let includePriceHistory : boolean = false
+      let includeCardRating : boolean = false
+
+      // The `include` search query will come in as a string, with ';' separating each param
+      // Must separate by ';' to get each param
+      const includeQueryParams : string | undefined = req.query.include as string
+      let includeOptions : string[]
+      if (includeQueryParams !== undefined) {
+        includeOptions = includeQueryParams.split(";")
+
+        if (includeOptions.includes('price-history')) {
+          includePriceHistory = true
+        }
+  
+        if (includeOptions.includes('card-rating')) {
+          includeCardRating = true
+        }
+      }
+      
+      const findOneCardData: PokemonCard = await this.card.findCardById(cardId, includePriceHistory, includeCardRating);
 
       res.status(200).json({ data: findOneCardData, message: 'findOne' });
     } catch (error) {
@@ -113,6 +132,33 @@ export class CardsController {
       // Send response back to user with HTTP status code 201 and 
       // created price history obj in JSON form
       res.status(201).json({ data: createdPriceHistory, message: 'created' }); 
+    }
+    catch(error) {
+
+      // TODO: look into what to do if post request fails 
+      next(error); 
+      res.status(500).json({ error: 'Internal Server Error' });
+
+    }
+  } 
+  
+  public createCardRating = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // priceHistoryData: price history info sent by user in post request
+      const cardRatingData : CardRating = req.body; 
+      // const priceHistoryData : CreatePriceHistoryDto = req.body;
+      const cardId : ObjectId | string = req.params.id; 
+      
+      // Inject the cardId from the URL path into priceHistoryData
+      cardRatingData.pokemonCardId = cardId; 
+
+      // Pass in priceHistoryData into the cards service method createPriceHistory()
+      // This will create a new card in the database and return it
+      const createdCardRating : CardRating = await this.card.createCardRating(cardId, cardRatingData); 
+
+      // Send response back to user with HTTP status code 201 and 
+      // created price history obj in JSON form
+      res.status(201).json({ data: createdCardRating, message: 'created' }); 
     }
     catch(error) {
 

--- a/api/src/dtos/cardRating.dto.ts
+++ b/api/src/dtos/cardRating.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, IsNotEmpty, IsNumber, IsDateString, Min, Max } from 'class-validator';
+import { ObjectId } from 'mongoose';
+
+export class CreateCardRatingDto {
+
+    @IsDateString()
+    @IsNotEmpty()
+    public date: Date;
+
+    @IsNumber()
+    @Min(0)
+    @Max(10)
+    public rating: number; 
+
+}

--- a/api/src/dtos/cards.dto.ts
+++ b/api/src/dtos/cards.dto.ts
@@ -23,8 +23,8 @@ export class CreateCardDto {
   @IsNotEmpty()
   public marketPrice: number; 
 
-  @IsArray()
-  public rating: number[]; 
+  // @IsArray()
+  // public rating: number[]; 
 
   @IsString()
   public image: string; 

--- a/api/src/interfaces/cardRating.interface.ts
+++ b/api/src/interfaces/cardRating.interface.ts
@@ -1,0 +1,8 @@
+import mongoose from "mongoose";
+
+export interface CardRating {
+    //Reference to pokemon card
+    pokemonCardId: mongoose.Types.ObjectId | string;
+    date: Date; 
+    rating: number; 
+  }

--- a/api/src/interfaces/cards.interface.ts
+++ b/api/src/interfaces/cards.interface.ts
@@ -6,6 +6,6 @@ export interface PokemonCard {
   description: string;
   salePrice: number;
   marketPrice: number;
-  rating: number[]; 
+  // rating: number[]; 
   image: string;
 }

--- a/api/src/interfaces/cards.interface.ts
+++ b/api/src/interfaces/cards.interface.ts
@@ -6,6 +6,5 @@ export interface PokemonCard {
   description: string;
   salePrice: number;
   marketPrice: number;
-  // rating: number[]; 
   image: string;
 }

--- a/api/src/models/cardRating.model.ts
+++ b/api/src/models/cardRating.model.ts
@@ -22,4 +22,4 @@ const CardRatingSchema: Schema = new Schema({
   }
 })
 
-export const CardRatingModel = model<PriceHistory>('CardRatingData', CardRatingSchema); 
+export const CardRatingModel = model<CardRating>('CardRatingData', CardRatingSchema); 

--- a/api/src/models/cardRating.model.ts
+++ b/api/src/models/cardRating.model.ts
@@ -1,10 +1,11 @@
 import { model, Schema } from 'mongoose';
 import { PriceHistory } from '@interfaces/priceHistory.interface'; 
+import { CardRating } from '@interfaces/cardRating.interface'
 import { PokemonCardModel } from './cards.model';
 
-const PriceHistorySchema: Schema = new Schema({
-  // Required because for a price history object to be created it must be linked to a card.
-  // Relates the priceHistory model back to the card model
+const CardRatingSchema: Schema = new Schema({
+  // Required because for a card rating object to be created it must be linked to a card.
+  // Relates the CardRating model back to the card model
   // https://medium.com/@brandon.lau86/one-to-many-relationships-with-mongodb-and-mongoose-in-node-express-d5c9d23d93c2
   pokemonCardId: {
     type: Schema.Types.ObjectId, 
@@ -15,14 +16,10 @@ const PriceHistorySchema: Schema = new Schema({
     type: Date,
     required: true,
   },
-  quantity: {
+  rating: {
     type: Number, 
     required: true, 
-  }, 
-  price: {
-    type: Number, 
-    required: true, 
-  },
+  }
 })
 
-export const PriceHistoryModel = model<PriceHistory>('PriceHistoryData', PriceHistorySchema); 
+export const CardRatingModel = model<PriceHistory>('CardRatingData', CardRatingSchema); 

--- a/api/src/models/cards.model.ts
+++ b/api/src/models/cards.model.ts
@@ -19,10 +19,6 @@ const PokemonCardSchema: Schema = new Schema({
     type: Number, 
     required: true, 
   },
-  // rating: {
-  //   type: Array, 
-  //   required: true, 
-  // },
   image: {
     type: String, 
     required: true, 

--- a/api/src/models/cards.model.ts
+++ b/api/src/models/cards.model.ts
@@ -19,10 +19,10 @@ const PokemonCardSchema: Schema = new Schema({
     type: Number, 
     required: true, 
   },
-  rating: {
-    type: Array, 
-    required: true, 
-  },
+  // rating: {
+  //   type: Array, 
+  //   required: true, 
+  // },
   image: {
     type: String, 
     required: true, 
@@ -39,6 +39,12 @@ whose pokemonCardId field matches the current PokemonCardModel's _id field
 */
 PokemonCardSchema.virtual('priceHistoryEntries', {
   ref: 'PriceHistoryData', 
+  localField: '_id', 
+  foreignField: 'pokemonCardId'
+})
+
+PokemonCardSchema.virtual('cardRatingEntries', {
+  ref: 'CardRatingData', 
   localField: '_id', 
   foreignField: 'pokemonCardId'
 })

--- a/api/src/routes/cards.route.ts
+++ b/api/src/routes/cards.route.ts
@@ -4,6 +4,7 @@ import { CardsController } from '@/controllers/cards.controller';
 import { ValidationMiddleware } from '@/middlewares/validation.middleware';
 import { CreateCardDto } from '@/dtos/cards.dto';
 import { CreatePriceHistoryDto } from '@/dtos/priceHistory.dto';
+import { CreateCardRatingDto } from '@/dtos/cardRating.dto';
 
 export class CardsRoute implements Routes {
   public path = '/cards';
@@ -23,6 +24,10 @@ export class CardsRoute implements Routes {
 
     // Route for post request for creating a new price history entry
     this.router.post(`${this.path}/:id/price-history`, ValidationMiddleware(CreatePriceHistoryDto), this.card.createPriceHistory)
+
+    // Route for post request for creating a new card rating entry
+    this.router.post(`${this.path}/:id/card-rating`, ValidationMiddleware(CreateCardRatingDto), this.card.createCardRating)
+
 
     this.router.get(`${this.path}/:id`, this.card.getCardById);
   }

--- a/api/src/services/cards.service.ts
+++ b/api/src/services/cards.service.ts
@@ -5,6 +5,8 @@ import { PokemonCardModel } from '@/models/cards.model';
 import { PriceHistory } from '@/interfaces/priceHistory.interface';
 import { PriceHistoryModel } from '@/models/priceHistory.model';
 import { ObjectId } from 'mongoose';
+import { CardRating } from '@/interfaces/cardRating.interface';
+import { CardRatingModel } from '@/models/cardRating.model';
 
 @Service()
 export class CardService {
@@ -30,10 +32,27 @@ export class CardService {
     return cards;
   }
 
-  public async findCardById(cardId: string, includePriceHistory: boolean): Promise<PokemonCard> {
+  public async findCardById(cardId: string, includePriceHistory: boolean, includeCardRating: boolean): Promise<PokemonCard> {
 
-    // Include price history
-    if(includePriceHistory) {
+    // Include price history and card rating
+    if(includePriceHistory && includeCardRating) {
+      // Find card by id and populate price history, then sort price history by date, descending
+      const findCard: PokemonCard = await PokemonCardModel.findOne({ _id: cardId })
+        .populate({
+          path: 'priceHistoryEntries',
+          options: { sort: {date: 'desc'}}
+        })
+        .populate({
+          path: 'cardRatingEntries', 
+          options: { sort: {date: 'desc'}}
+        }); 
+
+      if (!findCard) throw new HttpException(409, "Card doesn't exist");
+      return findCard;
+    }
+
+    // Include price history only
+    else if (includePriceHistory && !includeCardRating) {
       // Find card by id and populate price history, then sort price history by date, descending
       const findCard: PokemonCard = await PokemonCardModel.findOne({ _id: cardId })
         .populate({
@@ -42,9 +61,23 @@ export class CardService {
         }); 
 
       if (!findCard) throw new HttpException(409, "Card doesn't exist");
-      return findCard;
+      return findCard; 
     }
-    // Don't include price history
+
+    // Include card rating only
+    else if (!includePriceHistory && includeCardRating) {
+      // Find card by id and populate price history, then sort price history by date, descending
+      const findCard: PokemonCard = await PokemonCardModel.findOne({ _id: cardId })
+        .populate({
+          path: 'cardRatingEntries',
+          options: { sort: {date: 'desc'}}
+        }); 
+        
+      if (!findCard) throw new HttpException(409, "Card doesn't exist");
+      return findCard; 
+    }
+
+    // Don't include price history or card rating
     else {
       const findCard: PokemonCard = await PokemonCardModel.findOne({ _id: cardId });
       if (!findCard) throw new HttpException(409, "Card doesn't exist");
@@ -68,6 +101,15 @@ export class CardService {
     // if (!createdPriceHistory) throw new HttpException(409, "Price History doesn't exist");
 
     return createdPriceHistory;
+  }
+
+  public async createCardRating(cardId : ObjectId | string , cardRatingData: CardRating): Promise<CardRating> {
+    const createdCardRating: CardRating = await CardRatingModel.create(cardRatingData);
+    
+    //TODO: add some kind of catch for catching errors
+    // if (!createdCardRating) throw new HttpException(409, "Card Rating doesn't exist");
+
+    return createdCardRating;
   }
   
 }

--- a/api/src/services/cards.service.ts
+++ b/api/src/services/cards.service.ts
@@ -88,26 +88,26 @@ export class CardService {
   public async createCard(cardData: PokemonCard): Promise<PokemonCard> {
     const createdCard: PokemonCard = await PokemonCardModel.create(cardData);
     
-    //TODO: add some kind of catch for catching errors
-    // if (!createdCard) throw new HttpException(409, "Card doesn't exist");
+    // Catching errors if created card is undefined
+    if (!createdCard) throw new HttpException(409, "Card doesn't exist");
 
     return createdCard;
   }
   
-  public async createPriceHistory(cardId : ObjectId | string , priceHistoryData: PriceHistory): Promise<PriceHistory> {
+  public async createPriceHistory(priceHistoryData: PriceHistory): Promise<PriceHistory> {
     const createdPriceHistory: PriceHistory = await PriceHistoryModel.create(priceHistoryData);
     
-    //TODO: add some kind of catch for catching errors
-    // if (!createdPriceHistory) throw new HttpException(409, "Price History doesn't exist");
+    // Catching errors if created price history is undefined
+    if (!createdPriceHistory) throw new HttpException(409, "Price History doesn't exist");
 
     return createdPriceHistory;
   }
 
-  public async createCardRating(cardId : ObjectId | string , cardRatingData: CardRating): Promise<CardRating> {
+  public async createCardRating(cardRatingData: CardRating): Promise<CardRating> {
     const createdCardRating: CardRating = await CardRatingModel.create(cardRatingData);
     
-    //TODO: add some kind of catch for catching errors
-    // if (!createdCardRating) throw new HttpException(409, "Card Rating doesn't exist");
+    // Catching errors if created card rating is undefined
+    if (!createdCardRating) throw new HttpException(409, "Card Rating doesn't exist");
 
     return createdCardRating;
   }

--- a/api/src/test/cards.test.ts
+++ b/api/src/test/cards.test.ts
@@ -7,8 +7,6 @@ import { PokemonCardModel } from '@/models/cards.model';
 import { App } from '@/app'; 
 import { CardsRoute } from '@routes/cards.route'; 
 import { PokemonCard } from '@/interfaces/cards.interface';
-import { ClientSession } from 'mongodb';
-import { Document, Model, DocumentSetOptions, QueryOptions, Callback, UpdateQuery, AnyObject, PopulateOptions, MergeType, Query, SaveOptions, LeanDocument, ToObjectOptions, FlattenMaps, Require_id, UpdateWithAggregationPipeline, PathsToValidate, CallbackWithoutResult, pathsToSkip, Error, Connection } from 'mongoose';
 import { cardData } from './arrayOfCards';
 import { CreateCardRatingDto } from '@/dtos/cardRating.dto';
 import { CardRating } from '@/interfaces/cardRating.interface';
@@ -58,7 +56,6 @@ describe('Testing Cards', () => {
         description: 'Electric Type',
         salePrice: 1,
         marketPrice: 1,
-        // rating: [],
         image: 'Pikachu.png',
       }
 
@@ -75,7 +72,6 @@ describe('Testing Cards', () => {
       expect(response.body.data.description).toBe(cardData1.description);
       expect(response.body.data.salePrice).toBe(cardData1.salePrice);
       expect(response.body.data.marketPrice).toBe(cardData1.marketPrice);
-      // expect(response.body.data.rating).toStrictEqual(cardData1.rating);
       expect(response.body.data.image).toBe(cardData1.image);
 
     });
@@ -88,7 +84,6 @@ describe('Testing Cards', () => {
         description: 'Fire Type',
         salePrice: 23.10,
         marketPrice: 46.20,
-        // rating: [1, 9, 8, 2, 10],
         image: 'Charmander.png',
       }
 
@@ -105,7 +100,6 @@ describe('Testing Cards', () => {
       expect(response.body.data.description).toBe(cardData2.description);
       expect(response.body.data.salePrice).toBe(cardData2.salePrice);
       expect(response.body.data.marketPrice).toBe(cardData2.marketPrice);
-      // expect(response.body.data.rating).toStrictEqual(cardData2.rating);
       expect(response.body.data.image).toBe(cardData2.image);
     });
   });
@@ -123,7 +117,6 @@ describe('Testing Cards', () => {
         description: 'Electric Type',
         salePrice: 1,
         marketPrice: 1,
-        // rating: [],
         image: 'Pikachu.png',
       }
       const createdCard1: PokemonCard = await PokemonCardModel.create(cardData1);
@@ -168,7 +161,6 @@ describe('Testing Cards', () => {
         description: 'Water Type',
         salePrice: 2,
         marketPrice: 4,
-        // rating: [],
         image: 'Mudkip.png',
       }
       const createdCard1: PokemonCard = await PokemonCardModel.create(cardData1);
@@ -252,7 +244,6 @@ describe('Testing Cards', () => {
         description: 'Search', 
         salePrice: 1, 
         marketPrice: 2, 
-        // rating: [], 
         image: 'img',
       }
       let createdSameNameCards: PokemonCard[] = [];
@@ -356,7 +347,6 @@ describe('Testing Cards', () => {
       expect(result.body.data.description).toEqual(createdCards[0].description);
       expect(result.body.data.salePrice).toEqual(createdCards[0].salePrice);
       expect(result.body.data.marketPrice).toEqual(createdCards[0].marketPrice);
-      // expect(result.body.data.rating).toEqual(createdCards[0].rating);
       expect(result.body.data.image).toEqual(createdCards[0].image);
 
       // Check first price history entry
@@ -366,7 +356,6 @@ describe('Testing Cards', () => {
       const responseDateObject0 = new Date(+year0, +month0 - 1, +day0);
 
       expect(responseDateObject0.toString()).toBe(priceHistoryData0.date.toString());
-      // expect(result.body.data.priceHistoryEntries[0]._id.toString()).toEqual(createdPriceHistory1._id.toString());
       expect(result.body.data.priceHistoryEntries[0].pokemonCardId.toString()).toEqual(priceHistoryData0.pokemonCardId.toString());
       expect(result.body.data.priceHistoryEntries[0].price).toEqual(priceHistoryData0.price);
       expect(result.body.data.priceHistoryEntries[0].quantity).toEqual(priceHistoryData0.quantity);
@@ -379,7 +368,6 @@ describe('Testing Cards', () => {
       const responseDateObject3 = new Date(+year3, +month3 - 1, +day3);
 
       expect(responseDateObject3.toString()).toBe(priceHistoryData3.date.toString());
-      // expect(result.body.data.priceHistoryEntries[0]._id.toString()).toEqual(createdPriceHistory1._id.toString());
       expect(result.body.data.priceHistoryEntries[1].pokemonCardId.toString()).toEqual(priceHistoryData3.pokemonCardId.toString());
       expect(result.body.data.priceHistoryEntries[1].price).toEqual(priceHistoryData3.price);
       expect(result.body.data.priceHistoryEntries[1].quantity).toEqual(priceHistoryData3.quantity);
@@ -429,7 +417,6 @@ describe('Testing Cards', () => {
       expect(result.body.data.description).toEqual(createdCards[0].description);
       expect(result.body.data.salePrice).toEqual(createdCards[0].salePrice);
       expect(result.body.data.marketPrice).toEqual(createdCards[0].marketPrice);
-      // expect(result.body.data.rating).toEqual(createdCards[0].rating);
       expect(result.body.data.image).toEqual(createdCards[0].image);
 
       // Check first card rating entry
@@ -439,7 +426,6 @@ describe('Testing Cards', () => {
       const responseDateObject0 = new Date(+year0, +month0 - 1, +day0);
 
       expect(responseDateObject0.toString()).toBe(cardRatingData0.date.toString());
-      // expect(result.body.data.priceHistoryEntries[0]._id.toString()).toEqual(createdPriceHistory1._id.toString());
       expect(result.body.data.cardRatingEntries[0].pokemonCardId.toString()).toEqual(cardRatingData0.pokemonCardId.toString());
       expect(result.body.data.cardRatingEntries[0].rating).toEqual(cardRatingData0.rating);
 
@@ -451,7 +437,6 @@ describe('Testing Cards', () => {
       const responseDateObject3 = new Date(+year3, +month3 - 1, +day3);
 
       expect(responseDateObject3.toString()).toBe(cardRatingData3.date.toString());
-      // expect(result.body.data.priceHistoryEntries[0]._id.toString()).toEqual(createdPriceHistory1._id.toString());
       expect(result.body.data.cardRatingEntries[1].pokemonCardId.toString()).toEqual(cardRatingData3.pokemonCardId.toString());
       expect(result.body.data.cardRatingEntries[1].rating).toEqual(cardRatingData3.rating);
     });
@@ -489,16 +474,8 @@ describe('Testing Cards', () => {
       const createdPriceHistory1: PriceHistory = await PriceHistoryModel.create(priceHistoryData1);
 
 
-
-      // Pass the new ID to the [GET] by ID endpoint
-      // HOW TO STRING QUERIES???????????
-      // Rather, how to get mupltiple queries from one url
-      // const result = await request(app.getServer()).get(`${cardsRoute.path}/${cardId}?include=price-history&include=card-rating`);
-      // const result = await request(app.getServer()).get(`${cardsRoute.path}/${cardId}?include[]=price-history&include[]=card-rating`);
-      // const result = await request(app.getServer()).get(`${cardsRoute.path}/${cardId}`)
-      //   .query({
-      //     include: [`price-history`, `card-rating`]
-      //   });
+      // To pass in multiple queries, separate by ';'. 
+      // Can't use '&' or pass in arrays because Express will only use the last include query
       const result = await request(app.getServer()).get(`${cardsRoute.path}/${cardId}?include=price-history;card-rating`);
 
       // Expect good status code and cardId to match the route
@@ -511,7 +488,6 @@ describe('Testing Cards', () => {
       expect(result.body.data.description).toEqual(createdCards[1].description);
       expect(result.body.data.salePrice).toEqual(createdCards[1].salePrice);
       expect(result.body.data.marketPrice).toEqual(createdCards[1].marketPrice);
-      // expect(result.body.data.rating).toEqual(createdCards[1].rating);
       expect(result.body.data.image).toEqual(createdCards[1].image);
 
       // Check second price history entry
@@ -521,7 +497,6 @@ describe('Testing Cards', () => {
       const responseDateObject1 = new Date(+year1, +month1 - 1, +day1);
 
       expect(responseDateObject1.toString()).toBe(priceHistoryData1.date.toString());
-      // expect(result.body.data.priceHistoryEntries[0]._id.toString()).toEqual(createdPriceHistory1._id.toString());
       expect(result.body.data.priceHistoryEntries[1].pokemonCardId.toString()).toEqual(priceHistoryData1.pokemonCardId.toString());
       expect(result.body.data.priceHistoryEntries[1].price).toEqual(priceHistoryData1.price);
       expect(result.body.data.priceHistoryEntries[1].quantity).toEqual(priceHistoryData1.quantity);       
@@ -533,7 +508,6 @@ describe('Testing Cards', () => {
       const responseDateObject0 = new Date(+year0, +month0 - 1, +day0);
 
       expect(responseDateObject0.toString()).toBe(cardRatingData0.date.toString());
-      // expect(result.body.data.priceHistoryEntries[0]._id.toString()).toEqual(createdPriceHistory1._id.toString());
       expect(result.body.data.cardRatingEntries[0].pokemonCardId.toString()).toEqual(cardRatingData0.pokemonCardId.toString());
       expect(result.body.data.cardRatingEntries[0].rating).toEqual(cardRatingData0.rating);
 

--- a/api/src/test/cards.test.ts
+++ b/api/src/test/cards.test.ts
@@ -10,6 +10,9 @@ import { PokemonCard } from '@/interfaces/cards.interface';
 import { ClientSession } from 'mongodb';
 import { Document, Model, DocumentSetOptions, QueryOptions, Callback, UpdateQuery, AnyObject, PopulateOptions, MergeType, Query, SaveOptions, LeanDocument, ToObjectOptions, FlattenMaps, Require_id, UpdateWithAggregationPipeline, PathsToValidate, CallbackWithoutResult, pathsToSkip, Error, Connection } from 'mongoose';
 import { cardData } from './arrayOfCards';
+import { CreateCardRatingDto } from '@/dtos/cardRating.dto';
+import { CardRating } from '@/interfaces/cardRating.interface';
+import { CardRatingModel } from '@/models/cardRating.model';
 
 // Global variables 
 const cardsRoute = new CardsRoute();
@@ -55,7 +58,7 @@ describe('Testing Cards', () => {
         description: 'Electric Type',
         salePrice: 1,
         marketPrice: 1,
-        rating: [],
+        // rating: [],
         image: 'Pikachu.png',
       }
 
@@ -72,7 +75,7 @@ describe('Testing Cards', () => {
       expect(response.body.data.description).toBe(cardData1.description);
       expect(response.body.data.salePrice).toBe(cardData1.salePrice);
       expect(response.body.data.marketPrice).toBe(cardData1.marketPrice);
-      expect(response.body.data.rating).toStrictEqual(cardData1.rating);
+      // expect(response.body.data.rating).toStrictEqual(cardData1.rating);
       expect(response.body.data.image).toBe(cardData1.image);
 
     });
@@ -85,7 +88,7 @@ describe('Testing Cards', () => {
         description: 'Fire Type',
         salePrice: 23.10,
         marketPrice: 46.20,
-        rating: [1, 9, 8, 2, 10],
+        // rating: [1, 9, 8, 2, 10],
         image: 'Charmander.png',
       }
 
@@ -102,56 +105,99 @@ describe('Testing Cards', () => {
       expect(response.body.data.description).toBe(cardData2.description);
       expect(response.body.data.salePrice).toBe(cardData2.salePrice);
       expect(response.body.data.marketPrice).toBe(cardData2.marketPrice);
-      expect(response.body.data.rating).toStrictEqual(cardData2.rating);
+      // expect(response.body.data.rating).toStrictEqual(cardData2.rating);
       expect(response.body.data.image).toBe(cardData2.image);
     });
   });
 
 
-    // Test [POST] creating price history
-    describe('[POST] /cards/:id/price-history', () => {
-      it('Create Price History Entry', async () => {
-        const cardsRoute = new CardsRoute(); 
-        const app = new App([cardsRoute]); 
-  
-        // Create a sample card for the price history to reference
-        const cardData1: PokemonCard = {
-          name: 'Pikachu',
-          description: 'Electric Type',
-          salePrice: 1,
-          marketPrice: 1,
-          rating: [],
-          image: 'Pikachu.png',
-        }
-        const createdCard1: PokemonCard = await PokemonCardModel.create(cardData1);
-        const createdCard1Id = createdCard1._id; 
+  // Test [POST] creating price history
+  describe('[POST] /cards/:id/price-history', () => {
+    it('Create Price History Entry', async () => {
+      const cardsRoute = new CardsRoute(); 
+      const app = new App([cardsRoute]); 
 
-        const priceHistoryData1: CreatePriceHistoryDto = {
-          date: new Date(2023, 6, 13), 
-          quantity: 234, 
-          price: 568
-        }
-  
-        /**
-         * Request method creates new HTTP request that's used to send requests
-         * Post method creates post request to specified path
-         */
-        const response = await request(app.getServer())
-          .post(`${cardsRoute.path}/${createdCard1Id}/price-history`)
-          .send(priceHistoryData1); 
-            
-        // Need to create a date object from the string date given in the response object
-        const dateAndTimePriceHistory : string[] = response.body.data.date.split("T"); 
-        const dateOfPriceHistory : string = dateAndTimePriceHistory[0]; 
-        const [year, month, day] : string[] = dateOfPriceHistory.split('-');
-        const responseDateObject = new Date(+year, +month - 1, +day);        
+      // Create a sample card for the price history to reference
+      const cardData1: PokemonCard = {
+        name: 'Pikachu',
+        description: 'Electric Type',
+        salePrice: 1,
+        marketPrice: 1,
+        // rating: [],
+        image: 'Pikachu.png',
+      }
+      const createdCard1: PokemonCard = await PokemonCardModel.create(cardData1);
+      const createdCard1Id = createdCard1._id; 
 
-        expect(response.body.data.pokemonCardId).toBe(createdCard1Id.toString());
-        expect(responseDateObject.toString()).toBe(priceHistoryData1.date.toString());
-        expect(response.body.data.quantity).toBe(priceHistoryData1.quantity);
-        expect(response.body.data.price).toBe(priceHistoryData1.price);
-      });
+      const priceHistoryData1: CreatePriceHistoryDto = {
+        date: new Date(2023, 6, 13), 
+        quantity: 234, 
+        price: 568
+      }
+
+      /**
+       * Request method creates new HTTP request that's used to send requests
+       * Post method creates post request to specified path
+       */
+      const response = await request(app.getServer())
+        .post(`${cardsRoute.path}/${createdCard1Id}/price-history`)
+        .send(priceHistoryData1); 
+          
+      // Need to create a date object from the string date given in the response object
+      const dateAndTimePriceHistory : string[] = response.body.data.date.split("T"); 
+      const dateOfPriceHistory : string = dateAndTimePriceHistory[0]; 
+      const [year, month, day] : string[] = dateOfPriceHistory.split('-');
+      const responseDateObject = new Date(+year, +month - 1, +day);        
+
+      expect(response.body.data.pokemonCardId).toBe(createdCard1Id.toString());
+      expect(responseDateObject.toString()).toBe(priceHistoryData1.date.toString());
+      expect(response.body.data.quantity).toBe(priceHistoryData1.quantity);
+      expect(response.body.data.price).toBe(priceHistoryData1.price);
     });
+  });
+
+  // Test [POST] creating card rating
+  describe('[POST] /cards/:id/card-rating', () => {
+    it('Create Card Rating Entry', async () => {
+      const cardsRoute = new CardsRoute(); 
+      const app = new App([cardsRoute]); 
+
+      // Create a sample card for the price history to reference
+      const cardData1: PokemonCard = {
+        name: 'Mudkip',
+        description: 'Water Type',
+        salePrice: 2,
+        marketPrice: 4,
+        // rating: [],
+        image: 'Mudkip.png',
+      }
+      const createdCard1: PokemonCard = await PokemonCardModel.create(cardData1);
+      const createdCard1Id = createdCard1._id; 
+
+      const priceHistoryData1: CreateCardRatingDto = {
+        date: new Date(2023, 8, 22), 
+        rating: 7
+      }
+
+      /**
+       * Request method creates new HTTP request that's used to send requests
+       * Post method creates post request to specified path
+       */
+      const response = await request(app.getServer())
+        .post(`${cardsRoute.path}/${createdCard1Id}/card-rating`)
+        .send(priceHistoryData1); 
+          
+      // Need to create a date object from the string date given in the response object
+      const dateAndTimeCardRating : string[] = response.body.data.date.split("T"); 
+      const dateOfCardRating : string = dateAndTimeCardRating[0]; 
+      const [year, month, day] : string[] = dateOfCardRating.split('-');
+      const responseDateObject = new Date(+year, +month - 1, +day);        
+
+      expect(response.body.data.pokemonCardId).toBe(createdCard1Id.toString());
+      expect(responseDateObject.toString()).toBe(priceHistoryData1.date.toString());
+      expect(response.body.data.rating).toBe(priceHistoryData1.rating);
+    });
+  });
   
   // GET all cards. 
   describe('[GET] /card', () => {
@@ -206,7 +252,7 @@ describe('Testing Cards', () => {
         description: 'Search', 
         salePrice: 1, 
         marketPrice: 2, 
-        rating: [], 
+        // rating: [], 
         image: 'img',
       }
       let createdSameNameCards: PokemonCard[] = [];
@@ -234,6 +280,18 @@ describe('Testing Cards', () => {
       expect(result.body.data[2].name).toBe("Card 22");
       expect(result.body.data[0]._id).toHaveLength(24);
     });
+
+    // Get card by min/max card rating
+    it('Query min/max price of card', async () => {
+      const result = await request(app.getServer()).get(`${cardsRoute.path}?min=20&max=22`);
+      expect(result.status).toEqual(200);
+      expect(result.body.data.length).toBeGreaterThanOrEqual(1);
+      expect(result.body.data[0].name).toBe("Card 20");
+      expect(result.body.data[1].name).toBe("Card 21");
+      expect(result.body.data[2].name).toBe("Card 22");
+      expect(result.body.data[0]._id).toHaveLength(24);
+    });
+
   });
 
   // GET card by ID
@@ -298,7 +356,7 @@ describe('Testing Cards', () => {
       expect(result.body.data.description).toEqual(createdCards[0].description);
       expect(result.body.data.salePrice).toEqual(createdCards[0].salePrice);
       expect(result.body.data.marketPrice).toEqual(createdCards[0].marketPrice);
-      expect(result.body.data.rating).toEqual(createdCards[0].rating);
+      // expect(result.body.data.rating).toEqual(createdCards[0].rating);
       expect(result.body.data.image).toEqual(createdCards[0].image);
 
       // Check first price history entry
@@ -326,6 +384,161 @@ describe('Testing Cards', () => {
       expect(result.body.data.priceHistoryEntries[1].price).toEqual(priceHistoryData3.price);
       expect(result.body.data.priceHistoryEntries[1].quantity).toEqual(priceHistoryData3.quantity);
     });
+
+    it('Get card rating with include param', async () => {
+      // Create multiple card rating entries
+      const cardId = createdCards[0]._id;
+      const cardRatingData0: CardRating = {
+        pokemonCardId: cardId, 
+        date: new Date(2023, 8, 22), 
+        rating: 2
+      }
+      const cardRatingData1: CardRating = {
+        pokemonCardId: cardId, 
+        date: new Date(1999, 12, 31), 
+        rating: 5
+      }
+      const cardRatingData2: CardRating = {
+        pokemonCardId: cardId, 
+        date: new Date(2004, 1, 16), 
+        rating: 9, 
+      }
+      const cardRatingData3: CardRating = {
+        pokemonCardId: cardId, 
+        date: new Date(2016, 5, 8), 
+        rating: 6, 
+      }
+      const createdCardRating0: CardRating = await CardRatingModel.create(cardRatingData0);
+      const createdCardRating1: CardRating = await CardRatingModel.create(cardRatingData1);
+      const createdCardRating2: CardRating = await CardRatingModel.create(cardRatingData2);
+      const createdCardRating3: CardRating = await CardRatingModel.create(cardRatingData3);
+
+
+
+      // Pass the new ID to the [GET] by ID endpoint
+      const result = await request(app.getServer()).get(`${cardsRoute.path}/${cardId}?include=card-rating`);
+
+
+      // Expect good status code and cardId to match the route
+      expect(result.status).toEqual(200);
+      // Note had to use toString because of objectId type.
+      expect(result.body.data._id.toString()).toEqual(cardId.toString());
+
+      // Check pokemon card fields 
+      expect(result.body.data.name).toEqual(createdCards[0].name);
+      expect(result.body.data.description).toEqual(createdCards[0].description);
+      expect(result.body.data.salePrice).toEqual(createdCards[0].salePrice);
+      expect(result.body.data.marketPrice).toEqual(createdCards[0].marketPrice);
+      // expect(result.body.data.rating).toEqual(createdCards[0].rating);
+      expect(result.body.data.image).toEqual(createdCards[0].image);
+
+      // Check first card rating entry
+      const dateAndTimeCardRating0 : string[] = result.body.data.cardRatingEntries[0].date.split("T"); 
+      const dateOfCardRating0 : string = dateAndTimeCardRating0[0]; 
+      const [year0, month0, day0] : string[] = dateOfCardRating0.split('-');
+      const responseDateObject0 = new Date(+year0, +month0 - 1, +day0);
+
+      expect(responseDateObject0.toString()).toBe(cardRatingData0.date.toString());
+      // expect(result.body.data.priceHistoryEntries[0]._id.toString()).toEqual(createdPriceHistory1._id.toString());
+      expect(result.body.data.cardRatingEntries[0].pokemonCardId.toString()).toEqual(cardRatingData0.pokemonCardId.toString());
+      expect(result.body.data.cardRatingEntries[0].rating).toEqual(cardRatingData0.rating);
+
+
+      // Check second card rating entry
+      const dateAndTimeCardRating3 : string[] = result.body.data.cardRatingEntries[1].date.split("T"); 
+      const dateOfCardRating3 : string = dateAndTimeCardRating3[0]; 
+      const [year3, month3, day3] : string[] = dateOfCardRating3.split('-');
+      const responseDateObject3 = new Date(+year3, +month3 - 1, +day3);
+
+      expect(responseDateObject3.toString()).toBe(cardRatingData3.date.toString());
+      // expect(result.body.data.priceHistoryEntries[0]._id.toString()).toEqual(createdPriceHistory1._id.toString());
+      expect(result.body.data.cardRatingEntries[1].pokemonCardId.toString()).toEqual(cardRatingData3.pokemonCardId.toString());
+      expect(result.body.data.cardRatingEntries[1].rating).toEqual(cardRatingData3.rating);
+    });
+
+    it('Get price history and card rating with include param', async () => {
+      // Create multiple card rating and price history entries
+      const cardId = createdCards[1]._id;
+      const priceHistoryData0: PriceHistory = {
+        pokemonCardId: cardId, 
+        date: new Date(2023, 2, 8), 
+        quantity: 16, 
+        price: 90
+      }
+      const priceHistoryData1: PriceHistory = {
+        pokemonCardId: cardId, 
+        date: new Date(1999, 1, 10), 
+        quantity: 2, 
+        price: 439
+      }
+      const cardRatingData0: CardRating = {
+        pokemonCardId: cardId, 
+        date: new Date(2023, 2, 8), 
+        rating: 2
+      }
+      const cardRatingData1: CardRating = {
+        pokemonCardId: cardId, 
+        date: new Date(1999, 1, 10), 
+        rating: 5
+      }
+      
+
+      const createdCardRating0: CardRating = await CardRatingModel.create(cardRatingData0);
+      const createdCardRating1: CardRating = await CardRatingModel.create(cardRatingData1);
+      const createdPriceHistory0: PriceHistory = await PriceHistoryModel.create(priceHistoryData0);
+      const createdPriceHistory1: PriceHistory = await PriceHistoryModel.create(priceHistoryData1);
+
+
+
+      // Pass the new ID to the [GET] by ID endpoint
+      // HOW TO STRING QUERIES???????????
+      // Rather, how to get mupltiple queries from one url
+      // const result = await request(app.getServer()).get(`${cardsRoute.path}/${cardId}?include=price-history&include=card-rating`);
+      // const result = await request(app.getServer()).get(`${cardsRoute.path}/${cardId}?include[]=price-history&include[]=card-rating`);
+      // const result = await request(app.getServer()).get(`${cardsRoute.path}/${cardId}`)
+      //   .query({
+      //     include: [`price-history`, `card-rating`]
+      //   });
+      const result = await request(app.getServer()).get(`${cardsRoute.path}/${cardId}?include=price-history;card-rating`);
+
+      // Expect good status code and cardId to match the route
+      expect(result.status).toEqual(200);
+      // Note had to use toString because of objectId type.
+      expect(result.body.data._id.toString()).toEqual(cardId.toString());
+
+      // Check pokemon card fields 
+      expect(result.body.data.name).toEqual(createdCards[1].name);
+      expect(result.body.data.description).toEqual(createdCards[1].description);
+      expect(result.body.data.salePrice).toEqual(createdCards[1].salePrice);
+      expect(result.body.data.marketPrice).toEqual(createdCards[1].marketPrice);
+      // expect(result.body.data.rating).toEqual(createdCards[1].rating);
+      expect(result.body.data.image).toEqual(createdCards[1].image);
+
+      // Check second price history entry
+      const dateAndTimePriceHistory1 : string[] = result.body.data.priceHistoryEntries[1].date.split("T"); 
+      const dateOfPriceHistory1 : string = dateAndTimePriceHistory1[0]; 
+      const [year1, month1, day1] : string[] = dateOfPriceHistory1.split('-');
+      const responseDateObject1 = new Date(+year1, +month1 - 1, +day1);
+
+      expect(responseDateObject1.toString()).toBe(priceHistoryData1.date.toString());
+      // expect(result.body.data.priceHistoryEntries[0]._id.toString()).toEqual(createdPriceHistory1._id.toString());
+      expect(result.body.data.priceHistoryEntries[1].pokemonCardId.toString()).toEqual(priceHistoryData1.pokemonCardId.toString());
+      expect(result.body.data.priceHistoryEntries[1].price).toEqual(priceHistoryData1.price);
+      expect(result.body.data.priceHistoryEntries[1].quantity).toEqual(priceHistoryData1.quantity);       
+
+      // Check first card rating entry
+      const dateAndTimeCardRating0 : string[] = result.body.data.cardRatingEntries[0].date.split("T"); 
+      const dateOfCardRating0 : string = dateAndTimeCardRating0[0]; 
+      const [year0, month0, day0] : string[] = dateOfCardRating0.split('-');
+      const responseDateObject0 = new Date(+year0, +month0 - 1, +day0);
+
+      expect(responseDateObject0.toString()).toBe(cardRatingData0.date.toString());
+      // expect(result.body.data.priceHistoryEntries[0]._id.toString()).toEqual(createdPriceHistory1._id.toString());
+      expect(result.body.data.cardRatingEntries[0].pokemonCardId.toString()).toEqual(cardRatingData0.pokemonCardId.toString());
+      expect(result.body.data.cardRatingEntries[0].rating).toEqual(cardRatingData0.rating);
+
+
+    })
 
   });
 });

--- a/app/src/Components/CardDescription/CardDescription.tsx
+++ b/app/src/Components/CardDescription/CardDescription.tsx
@@ -14,7 +14,27 @@ interface CardDescriptionProps {
     cardInfo: PokemonCard; 
     cardRatingAverageProp: number | string; 
     onNewPriceHistorySubmission: (priceHistoryPostData: PriceHistory) => void
+    
 }
+
+/**
+ * Used this stack-overflow article for how to truncate numbers
+ * in JavaScript: https://stackoverflow.com/questions/4912788/truncate-not-round-off-decimal-numbers-in-javascript
+ * 
+ * @param num Number to truncate
+ * @param digits Number of decimal places to truncate to 
+ * @returns Truncated number
+ */
+const truncateDecimals  = (num: number, digits: number) => {
+    var numS = num.toString(),
+        decPos = numS.indexOf('.'),
+        substrLength = decPos == -1 ? numS.length : 1 + decPos + digits,
+        trimmedResult = numS.substring(0, substrLength),
+        finalResult = isNaN(Number(trimmedResult)) ? 0 : trimmedResult;
+
+    return parseFloat(finalResult.toString());
+}
+
 
 const CardDescription: FC<CardDescriptionProps> = ({ cardInfo, cardRatingAverageProp, onNewPriceHistorySubmission}): JSX.Element => {
     const DEFAULT_NAME : string = 'Pokemon'
@@ -77,6 +97,11 @@ const CardDescription: FC<CardDescriptionProps> = ({ cardInfo, cardRatingAverage
 
     // Only allows price history entry to be submitted if priceText is not empty
     let isSubmitDisabled = !priceText
+    
+    // If the cardRatingAverageProp is a number, truncate it so that only 1 decimal displayed
+    if (typeof cardRatingAverageProp === 'number') {
+        cardRatingAverageProp = truncateDecimals(cardRatingAverageProp, 1)
+    }
 
     return (
         <Card className="card-desc-comp">
@@ -86,14 +111,12 @@ const CardDescription: FC<CardDescriptionProps> = ({ cardInfo, cardRatingAverage
                 <Card.Subtitle className="card-desc-sale-price">${cardInfo && cardInfo.salePrice ? cardInfo.salePrice : DEFAULT_SALE_PRICE}</Card.Subtitle>
 
                 <Card.Text className="card-desc-price-rtn">
-                    Market Price: 
+                    Market Price: &nbsp; 
                     <span className="card-desc-market-price">
                         ${cardInfo && cardInfo.marketPrice ? cardInfo.marketPrice : DEFAULT_MARKET_PRICE}
-                    </span>  |  Card Rating: 
+                    </span> &nbsp; | &nbsp; Card Rating: &nbsp; 
                     <span className="card-desc-rating">
-                        {/* {cardInfo && cardRatingAverageProp ? cardRatingAverageProp : DEFAULT_RATING} */}
                         {cardRatingAverageProp}
-                        {/* {cardInfo && DEFAULT_RATING} */}
                     </span>
                 </Card.Text>
 

--- a/app/src/Components/CardDescription/CardDescription.tsx
+++ b/app/src/Components/CardDescription/CardDescription.tsx
@@ -12,7 +12,7 @@ import { CardRating } from "../../../../api/src/interfaces/cardRating.interface"
 
 interface CardDescriptionProps {
     cardInfo: PokemonCard; 
-    cardRatingAverageProp: number; 
+    cardRatingAverageProp: number | string; 
     onNewPriceHistorySubmission: (priceHistoryPostData: PriceHistory) => void
 }
 
@@ -91,7 +91,8 @@ const CardDescription: FC<CardDescriptionProps> = ({ cardInfo, cardRatingAverage
                         ${cardInfo && cardInfo.marketPrice ? cardInfo.marketPrice : DEFAULT_MARKET_PRICE}
                     </span>  |  Card Rating: 
                     <span className="card-desc-rating">
-                        {cardInfo && cardRatingAverageProp ? cardRatingAverageProp : DEFAULT_RATING}
+                        {/* {cardInfo && cardRatingAverageProp ? cardRatingAverageProp : DEFAULT_RATING} */}
+                        {cardRatingAverageProp}
                         {/* {cardInfo && DEFAULT_RATING} */}
                     </span>
                 </Card.Text>

--- a/app/src/Components/CardDescription/CardDescription.tsx
+++ b/app/src/Components/CardDescription/CardDescription.tsx
@@ -8,13 +8,15 @@ import { PokemonCard } from "../../../../api/src/interfaces/cards.interface";
 import './CardDescription.css';
 import '../ProductCard/Cardback.jpg'
 import { PriceHistory } from "../../../../api/src/interfaces/priceHistory.interface";
+import { CardRating } from "../../../../api/src/interfaces/cardRating.interface";
 
 interface CardDescriptionProps {
     cardInfo: PokemonCard; 
+    cardRatingAverageProp: number; 
     onNewPriceHistorySubmission: (priceHistoryPostData: PriceHistory) => void
 }
 
-const CardDescription: FC<CardDescriptionProps> = ({ cardInfo, onNewPriceHistorySubmission}): JSX.Element => {
+const CardDescription: FC<CardDescriptionProps> = ({ cardInfo, cardRatingAverageProp, onNewPriceHistorySubmission}): JSX.Element => {
     const DEFAULT_NAME : string = 'Pokemon'
     const DEFAULT_IMAGE : string = './Cardback.jpg'
     const DEFAULT_SALE_PRICE : number = NaN
@@ -89,7 +91,8 @@ const CardDescription: FC<CardDescriptionProps> = ({ cardInfo, onNewPriceHistory
                         ${cardInfo && cardInfo.marketPrice ? cardInfo.marketPrice : DEFAULT_MARKET_PRICE}
                     </span>  |  Card Rating: 
                     <span className="card-desc-rating">
-                        {cardInfo && cardInfo.rating ? cardInfo.rating : DEFAULT_RATING}
+                        {cardInfo && cardRatingAverageProp ? cardRatingAverageProp : DEFAULT_RATING}
+                        {/* {cardInfo && DEFAULT_RATING} */}
                     </span>
                 </Card.Text>
 

--- a/app/src/Components/CardRater/CardRater.tsx
+++ b/app/src/Components/CardRater/CardRater.tsx
@@ -16,8 +16,6 @@ const sliderTrackColor : NodeListOf<Element> = document.querySelectorAll('input[
 const slider : any = document.getElementById("myinput"); 
 
 const CardRater: FC<CardRatingProps> = ({ cardInfo, onNewCardRatingSubmission}): JSX.Element => {
-// export function CardRater() {
-    // const inputRef : any = React.createRef()
 
     const [sliderValue, setSliderValue] = useState<number>(0);
     
@@ -25,21 +23,13 @@ const CardRater: FC<CardRatingProps> = ({ cardInfo, onNewCardRatingSubmission}):
     const max : number = 10; 
 
     const updateSliderColor = (event : any) : void => {
-        // Parse slider value as an integer
-        const newSliderValue = parseInt(event.target.value, 10); 
-        setSliderValue(newSliderValue); 
-        console.log("sliderValue: " + sliderValue); 
 
-        const progress : string = (newSliderValue-min)/(max-min)*100 + '%'; 
-        event.target.style.background = 'linear-gradient(90deg, #FCCD29 0% ${progress}%, #94938d ${progress}% 100%)'; 
+        console.log("True slider value: " + event.target.value)
+        setSliderValue(event.target.value); 
 
-        // setSliderValue(event.target.value); 
-        // console.log(sliderValue); 
+        const progress : string = (sliderValue-min)/(max-min)*100 + '%'; 
+        event.target.style.background = `linear-gradient(90deg, #FCCD29 0% ${progress}%, #94938d ${progress}% 100%)`; 
 
-        // const progress : string = (sliderValue-min)/(max-min)*100 + '%'; 
-
-        // const newBackgroundStyle = `linear-gradient(90deg, #FCCD29 0% ${progress}%, #94938d ${progress}% 100%)`
-        // inputRef.current.style.background = newBackgroundStyle
     }
     
     let progressUpdate : string = (sliderValue-min)/(max-min)*100 + '%';
@@ -48,20 +38,27 @@ const CardRater: FC<CardRatingProps> = ({ cardInfo, onNewCardRatingSubmission}):
     }
 
 
+    /**
+     * Function for handling slider form submission. 
+     * Will create new card rating object, post it to API, 
+     * and update current card rating average. 
+     * 
+     * @param e event from slider form submission
+     */
     const handleSubmit = async (e: any) => {
         e.preventDefault()
         console.log("Button Clicked")
         console.log("Card ID: " + cardInfo._id)
 
-
         try {
+            // Make new CardRating object
             const cardRatingPostData: CardRating = {
                 pokemonCardId: String(cardInfo._id), 
                 date: new Date(), 
                 rating: Number(sliderValue)
             }
 
-            // Fetch/post request with newly created card rating object...
+            // Fetch and do post request with newly created card rating object...
             const response = await fetch(`http://localhost:3000/cards/${cardInfo._id}/card-rating`, {
                 method: 'POST', 
                 headers: {

--- a/app/src/Pages/DetailsPage/Details.tsx
+++ b/app/src/Pages/DetailsPage/Details.tsx
@@ -21,6 +21,8 @@ function Details() {
   // Grabs the args/params passed in through useNavigate's URL
   const params = useParams(); 
 
+  const EMPTY_CARD_RATING_MSG : string = 'No card ratings made yet'; 
+
   /*
   'card' state variable is optional because we are already using the 
   receivedStatePokemonCard from the ProductCard component. 
@@ -28,7 +30,24 @@ function Details() {
   const [card, setCard] = useState<PokemonCard>(); 
   const [priceHistory, setPriceHistory ] = useState<PriceHistory[]>([]); 
   const [cardRating, setCardRating] = useState<CardRating[]>([]); 
-  const [cardRatingAverage, setCardRatingAverage] = useState<number>(0);
+
+  /**
+   * Could not make cardRatingAverage as a state variable because 
+   * it would need a default value. If you used a default value of 0, 
+   * then anytime you clicked to view a card's details, the card
+   * rating would display as 0. 
+   */  
+  let cardRatingAverage : number | string; 
+
+  if(cardRating.length <= 0) {
+    cardRatingAverage = EMPTY_CARD_RATING_MSG; 
+  }
+  else {
+    cardRatingAverage = cardRating.reduce((accumulator, currentCardRatingObj) => {
+      return accumulator + currentCardRatingObj.rating
+    }, 0) / cardRating.length; 
+  }
+
 
   /*
   Function to be called when new price history is posted. 
@@ -53,9 +72,25 @@ function Details() {
     setCardRating(cardRating => [newCardRatingSubmission, ...cardRating]); 
     console.log("card rating state after adding stuff in: ", cardRating); 
 
-    let cardRatingAvg : number = cardRating.reduce((accumulator, currentCardRatingObj) => {
-      return accumulator + currentCardRatingObj.rating
-    }, 0) / cardRating.length
+    /*
+    Compute the new average of the card ratings, including the newly posted card rating
+    in your calculations. 
+    Use reduce() iterator to get the sum of all the card ratings. Then divide by total 
+    number of ratings
+    */
+    if(cardRating.length <= 0) {
+      cardRatingAverage = EMPTY_CARD_RATING_MSG; 
+    }
+    else {
+      cardRatingAverage = cardRating.reduce((accumulator, currentCardRatingObj) => {
+        return accumulator + currentCardRatingObj.rating
+      }, 0) / cardRating.length; 
+    }
+    // cardRatingAverage = cardRating.reduce((accumulator, currentCardRatingObj) => {
+    //   return accumulator + currentCardRatingObj.rating
+    // }, 0) / cardRating.length
+
+    // // setCardRatingAverage(cardRatingAvg); 
 
   }
 
@@ -99,8 +134,12 @@ function Details() {
 
       <div className="info-flexbox">
         <PriceHistoryComponent priceHistoryArray={Array.isArray(priceHistory) ? priceHistory : []}/>
-        {/* <CardRater onNewCardRatingSubmission={handleNewCardRatingSubmission}/> */}
-        <CardRater/>
+
+        <CardRater 
+          cardInfo={receivedStatePokemonCard as PokemonCard}
+          onNewCardRatingSubmission={handleNewCardRatingSubmission}
+        />
+        {/* <CardRater/> */}
       </div>
       
       <Footer />

--- a/app/src/Pages/DetailsPage/Details.tsx
+++ b/app/src/Pages/DetailsPage/Details.tsx
@@ -12,6 +12,13 @@ import { PriceHistory } from "../../../../api/src/interfaces/priceHistory.interf
 import { CardRating } from "../../../../api/src/interfaces/cardRating.interface";
 
 
+function findAverageCardRating(cardRatingArray: CardRating[]) : number | string {
+
+  return cardRatingArray.reduce((accumulator, currentCardRatingObj) => {
+    return accumulator + currentCardRatingObj.rating
+  }, 0) / cardRatingArray.length; 
+
+}
 
 
 function Details() {
@@ -39,16 +46,7 @@ function Details() {
    * NOTE: if there are no card ratings, will instead display 
    *       message saying no card ratings have been given. 
    */  
-  let cardRatingAverage : number | string; 
-
-  if(cardRating.length <= 0) {
-    cardRatingAverage = EMPTY_CARD_RATING_MSG; 
-  }
-  else {
-    cardRatingAverage = cardRating.reduce((accumulator, currentCardRatingObj) => {
-      return accumulator + currentCardRatingObj.rating
-    }, 0) / cardRating.length; 
-  }
+  let cardRatingAverage : number | string = cardRating.length <= 0 ? EMPTY_CARD_RATING_MSG : findAverageCardRating(cardRating);
 
 
   /*
@@ -80,14 +78,7 @@ function Details() {
      * Use reduce() iterator to get the sum of all the card ratings. Then divide by total 
      * number of ratings.
      */
-    if(cardRating.length <= 0) {
-      cardRatingAverage = EMPTY_CARD_RATING_MSG; 
-    }
-    else {
-      cardRatingAverage = cardRating.reduce((accumulator, currentCardRatingObj) => {
-        return accumulator + currentCardRatingObj.rating
-      }, 0) / cardRating.length; 
-    }
+    cardRatingAverage = cardRating.length <= 0 ? EMPTY_CARD_RATING_MSG : findAverageCardRating(cardRating);
 
   }
 

--- a/app/src/Pages/DetailsPage/Details.tsx
+++ b/app/src/Pages/DetailsPage/Details.tsx
@@ -21,7 +21,7 @@ function Details() {
   // Grabs the args/params passed in through useNavigate's URL
   const params = useParams(); 
 
-  const EMPTY_CARD_RATING_MSG : string = 'No card ratings made yet'; 
+  const EMPTY_CARD_RATING_MSG : string = 'No card ratings'; 
 
   /*
   'card' state variable is optional because we are already using the 
@@ -36,6 +36,8 @@ function Details() {
    * it would need a default value. If you used a default value of 0, 
    * then anytime you clicked to view a card's details, the card
    * rating would display as 0. 
+   * NOTE: if there are no card ratings, will instead display 
+   *       message saying no card ratings have been given. 
    */  
   let cardRatingAverage : number | string; 
 
@@ -72,12 +74,12 @@ function Details() {
     setCardRating(cardRating => [newCardRatingSubmission, ...cardRating]); 
     console.log("card rating state after adding stuff in: ", cardRating); 
 
-    /*
-    Compute the new average of the card ratings, including the newly posted card rating
-    in your calculations. 
-    Use reduce() iterator to get the sum of all the card ratings. Then divide by total 
-    number of ratings
-    */
+    /**
+     * Compute the new average of the card ratings, including the newly posted card rating
+     * in your calculations. 
+     * Use reduce() iterator to get the sum of all the card ratings. Then divide by total 
+     * number of ratings.
+     */
     if(cardRating.length <= 0) {
       cardRatingAverage = EMPTY_CARD_RATING_MSG; 
     }
@@ -86,11 +88,6 @@ function Details() {
         return accumulator + currentCardRatingObj.rating
       }, 0) / cardRating.length; 
     }
-    // cardRatingAverage = cardRating.reduce((accumulator, currentCardRatingObj) => {
-    //   return accumulator + currentCardRatingObj.rating
-    // }, 0) / cardRating.length
-
-    // // setCardRatingAverage(cardRatingAvg); 
 
   }
 
@@ -139,7 +136,6 @@ function Details() {
           cardInfo={receivedStatePokemonCard as PokemonCard}
           onNewCardRatingSubmission={handleNewCardRatingSubmission}
         />
-        {/* <CardRater/> */}
       </div>
       
       <Footer />

--- a/app/src/Pages/DetailsPage/Details.tsx
+++ b/app/src/Pages/DetailsPage/Details.tsx
@@ -9,6 +9,8 @@ import { useLocation, useParams } from 'react-router-dom';
 import { PokemonCard } from '../../../../api/src/interfaces/cards.interface';
 import { useEffect, useState } from 'react';
 import { PriceHistory } from "../../../../api/src/interfaces/priceHistory.interface";
+import { CardRating } from "../../../../api/src/interfaces/cardRating.interface";
+
 
 
 
@@ -25,6 +27,8 @@ function Details() {
   */
   const [card, setCard] = useState<PokemonCard>(); 
   const [priceHistory, setPriceHistory ] = useState<PriceHistory[]>([]); 
+  const [cardRating, setCardRating] = useState<CardRating[]>([]); 
+  const [cardRatingAverage, setCardRatingAverage] = useState<number>(0);
 
   /*
   Function to be called when new price history is posted. 
@@ -38,14 +42,33 @@ function Details() {
     console.log("price history state after adding stuff in: ", priceHistory); 
   }
 
+  /*
+  Function to be called when new card rating is posted. 
+  Appends new card rating entry to the card rating array. 
+  Then, React will automatically re-render the CardDescription component
+  to include the newly computed averages of all the card ratings.
+  */
+  const handleNewCardRatingSubmission = (newCardRatingSubmission: CardRating) => {
+    console.log("card rating state before adding stuff in: ", cardRating); 
+    setCardRating(cardRating => [newCardRatingSubmission, ...cardRating]); 
+    console.log("card rating state after adding stuff in: ", cardRating); 
+
+    let cardRatingAvg : number = cardRating.reduce((accumulator, currentCardRatingObj) => {
+      return accumulator + currentCardRatingObj.rating
+    }, 0) / cardRating.length
+
+  }
+
   useEffect(() => {
     const fetchCurrentCard = async() => {
       try{
-        const result = await fetch(`http://localhost:3000/cards/${params.id}?include=price-history`)
+        // Must include both card rating and price history
+        const result = await fetch(`http://localhost:3000/cards/${params.id}?include=price-history;card-rating`)
         const pokemonCardFetchedData = await result.json(); 
        
         setCard(pokemonCardFetchedData.data); 
         setPriceHistory(pokemonCardFetchedData.data.priceHistoryEntries); 
+        setCardRating(pokemonCardFetchedData.data.cardRatingEntries); 
       }
       catch(error) {
         console.log(error); 
@@ -68,11 +91,16 @@ function Details() {
        * Optionally: can also pass in this component's state variable 'card', which is obtained
        * along with the price history from the fetch statement. 
       */}
-      <CardDescription cardInfo={receivedStatePokemonCard as PokemonCard} onNewPriceHistorySubmission={handleNewPriceHistorySubmission}/>
+      <CardDescription 
+        cardInfo={receivedStatePokemonCard as PokemonCard} 
+        cardRatingAverageProp={cardRatingAverage}
+        onNewPriceHistorySubmission={handleNewPriceHistorySubmission}
+      />
 
       <div className="info-flexbox">
         <PriceHistoryComponent priceHistoryArray={Array.isArray(priceHistory) ? priceHistory : []}/>
-        <CardRater />
+        {/* <CardRater onNewCardRatingSubmission={handleNewCardRatingSubmission}/> */}
+        <CardRater/>
       </div>
       
       <Footer />


### PR DESCRIPTION
I was originally going to do separate pull requests for backend-rating and frontend-rating, but I realized that changing the interfaces/models/other stuff in the backend would break stuff in the frontend. Since I didn't want to merge only code that broke the frontend, I ended up just doing everything in one big PR. 

Overall, for card ratings, I mimicked the code structure of price histories. I 'included' them in the pokemon card objects as virtual fields and populated them. 

In frontend, I made it so that it would automatically update the average value of the rating if you submitted a new card rating entry. (Also fixed the bugs with the slider!)