### PR TITLE
Reset Queries when going Home

### DIFF
--- a/app/src/Components/CardDescription/CardDescription.tsx
+++ b/app/src/Components/CardDescription/CardDescription.tsx
@@ -96,7 +96,7 @@ const CardDescription: FC<CardDescriptionProps> = ({ cardInfo, cardRatingAverage
     }
 
     // Only allows price history entry to be submitted if priceText is not empty
-    let isSubmitDisabled = !priceText
+    let isSubmitDisabled = !priceText || Number(priceText) < 0;
     
     // If the cardRatingAverageProp is a number, truncate it so that only 1 decimal displayed
     if (typeof cardRatingAverageProp === 'number') {

--- a/app/src/Components/NavBar/Nav.tsx
+++ b/app/src/Components/NavBar/Nav.tsx
@@ -24,6 +24,32 @@ function TopNav ({ onSearchChange, onSortClick, onOrderClick, onMinChange, onMax
   const [minPrice, setMinPrice] = useState("");
   const [maxPrice, setMaxPrice] = useState("");
 
+  /**
+   * When the user clicks the home button or Pokémon logo, 
+   * reset all the filters/query parameters so that default 
+   * order of cards is displayed.
+   */
+  const handleGoHome = () : void => {
+    // Reset all the filters (passes empty strings to the state variables
+    // that are used to filter the cards)
+    onSearchChange("");
+    onSortClick("");
+    onOrderClick("");
+    onMinChange("");
+    onMaxChange("");
+
+    /**
+     * OPTIONAL: Reset the min and max price fields to empty strings
+     *          so that there are not values in the input fields either
+     * 
+     * NOTE: Unable to reset values in search field because we
+     *      did not use state variables for the search field.
+     */
+    setMinPrice("");
+    setMaxPrice("");
+  }
+
+  
   // When the user sorts the cards
   const handleSortClick = (e: any) => {
     // Change the sort value (Classes correspond to the sort type)
@@ -40,16 +66,19 @@ function TopNav ({ onSearchChange, onSortClick, onOrderClick, onMinChange, onMax
   }
 
   // When user changes min price filter
+  // Used for logging value when typed in min price field
   const handleMinChange = (e: any) => {
     setMinPrice(e.target.value);
   }
 
   // When user changes max price filter
+  // Used for logging value when typed in max price field
   const handleMaxChange = (e: any) => {
     setMaxPrice(e.target.value);
   }
  
   // When the user filters by price
+  // Used for submitting min/max values for filtering
   const handleFilterSubmit = (e: any) => {
     //e.preventDefualt();
     console.log("New Filter")
@@ -66,7 +95,10 @@ function TopNav ({ onSearchChange, onSortClick, onOrderClick, onMinChange, onMax
     <Navbar id="top-nav" expand="lg" variant="dark">
       <Container>
         <Navbar.Brand href="#home">
-          <Link to="/">
+          <Link 
+            to="/"
+            onClick={() => handleGoHome()}
+          >
             <img 
               src={pokemonLogo}
               height="30"
@@ -79,7 +111,15 @@ function TopNav ({ onSearchChange, onSortClick, onOrderClick, onMinChange, onMax
           <Navbar.Toggle aria-controls="basic-navbar-nav" />
             <Navbar.Collapse id="basic-navbar-nav" >
               <Nav className="me-auto" >
-                <Nav.Link href="#home" className='collapse-btn'><Link className="top-nav-link" to="/">Home</Link></Nav.Link>
+                <Nav.Link href="#home" className='collapse-btn'>
+                  <Link 
+                    className="top-nav-link" 
+                    to="/" 
+                    onClick={() => handleGoHome()}
+                  >
+                    Home
+                  </Link>
+                </Nav.Link>
               </Nav>
               <Nav>
                 <NavDropdown title="Sort By" id="basic-nav-dropdown" className="sort-filter collapse-btn">


### PR DESCRIPTION
Made the following changes: 

1) Require all price history entries to be greater than or equal to $0. (I'm open to changing so that it requires it to be strictly greater than $0. Feel free to let me know your opinion)

2) Pressing home button or Pokémon logo will reset all filters/search parameters. This way, the default order of the cards will be displayed. I noticed that this kind of behavior is in a bunch of websites