### PR TITLE
Fix Details Page Styling

### DIFF
--- a/api/src/test/cards.test.ts
+++ b/api/src/test/cards.test.ts
@@ -137,15 +137,15 @@ describe('Testing Cards', () => {
         .send(priceHistoryData1); 
           
       // Need to create a date object from the string date given in the response object
-      const dateAndTimePriceHistory : string[] = response.body.data.date.split("T"); 
+      const dateAndTimePriceHistory : string[] = response.body.data[0].date.split("T"); 
       const dateOfPriceHistory : string = dateAndTimePriceHistory[0]; 
       const [year, month, day] : string[] = dateOfPriceHistory.split('-');
       const responseDateObject = new Date(+year, +month - 1, +day);        
 
-      expect(response.body.data.pokemonCardId).toBe(createdCard1Id.toString());
+      expect(response.body.data[0].pokemonCardId).toBe(createdCard1Id.toString());
       expect(responseDateObject.toString()).toBe(priceHistoryData1.date.toString());
-      expect(response.body.data.quantity).toBe(priceHistoryData1.quantity);
-      expect(response.body.data.price).toBe(priceHistoryData1.price);
+      expect(response.body.data[0].quantity).toBe(priceHistoryData1.quantity);
+      expect(response.body.data[0].price).toBe(priceHistoryData1.price);
     });
   });
 

--- a/app/src/Components/CardDescription/CardDescription.css
+++ b/app/src/Components/CardDescription/CardDescription.css
@@ -3,6 +3,9 @@
     border: 0px;
     display: flex; 
     flex-direction: row;
+    flex-wrap: wrap; 
+    justify-content: center;
+    
 
 }
 
@@ -15,6 +18,10 @@
 }
 
 .card-desc-body {
+    /* Calculated this width so that the card description
+       would shift at the same time that the card rater and 
+       price history components shifts when the screen minimizes*/
+    width: 51.9%;
     padding: 1% 3% 3% 3%; 
     float: right; 
     margin: 0 2rem; 

--- a/app/src/Components/CardDescription/CardDescription.css
+++ b/app/src/Components/CardDescription/CardDescription.css
@@ -29,7 +29,7 @@
 
 .card-desc-name {
     font-family: Inter;
-    font-size: 48px;
+    font-size: 2.5rem;
     font-weight: 700;
     line-height: 58px;
     letter-spacing: 0em;
@@ -38,7 +38,7 @@
 
 .card-desc-sale-price {
     font-family: Inter;
-    font-size: 36px;
+    font-size: 1.7rem;
     font-weight: 900;
     line-height: 44px;
     letter-spacing: 0em;

--- a/app/src/Pages/DetailsPage/Details.css
+++ b/app/src/Pages/DetailsPage/Details.css
@@ -1,7 +1,9 @@
 .info-flexbox {
     display: flex; 
+    flex-wrap: wrap; 
     align-content: center; 
     gap: 2rem; 
     padding: 1rem 5rem;
-    margin-top: 1rem; {/*CHANGE THIS*/}
+    margin-top: 1rem; 
+    /* {CHANGE THIS} */
 }


### PR DESCRIPTION
- fixed a price history API test that was broken (I think I might've broken it in a previous PR and didn't notice)
- fixed details page styling issue where components wouldn't shift when page became smaller
- NOTE: the card description component is naturally left aligned. So, when you make the screen smaller, the other components (image, card rater, price history) are all centered aligned, but the card description looks left aligned. Could fix by making all others not center aligned. Up to you. Or we could just leave it be